### PR TITLE
Replace deprecated core23 library with nucelos library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/browser-kit": "^4.4 || ^5.0.4"
     },
     "suggest": {
-        "core23/shariff-bundle": "If you need a GDPR conform social media widget integration"
+        "nucleos/shariff-bundle": "If you need a GDPR conform social media widget integration"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

The `shariff-bundle` dependency was moved to the `nucleos` organisation.
